### PR TITLE
Installation via Docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ This is an installation package of the Easyminer/R bundle for the docker environ
 
 ### EasyMiner with R backend
 
+Installation using Docker compose (recommended):
+
+Requirements: Docker compose 1.12+, Docker 1.12+
+
+Download docker-compose.yml from this repository and at same directory run following commands:
+
+```bash
+docker-compose pull
+docker-compose up --force-recreate -d easyminer
+```
+
+Instalation without Docker compose (alternative):
+
 Requirements: Docker 1.12+
 
 ```bash
@@ -66,13 +79,13 @@ docker run -d -p 8893:8893 -p 8891:8891 -p 8892:8892 --name easyminer-backend -e
 docker pull kizi/easyminer-scorer:v2.4
 docker run -d -p 8080:8080 --name easyminer-scorer --network easyminer kizi/easyminer-scorer:v2.4
 ```
+### Additional information
 
 * Web GUI: **http://\<docker-server\>:8894/easyminercenter**
 * Frontend re-install page: *http://\<docker-server\>:8894/easyminercenter/install* (password: 12345)
 * Frontend API endpoint: **http://\<docker-server\>:8894/easyminercenter/api**
 * HEADS UP: Use IP address or URL for docker-server, NOT localhost! Using localhost will block crossite scripting, eventually leading to error
 * HEADS UP: If you  run EasyMiner in virtual machine, use Bridged adapter (not NAT)
-### Additional information
 
 REST API endpoints are accessible on:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: mariadb:10
     environment:
       - MYSQL_ROOT_PASSWORD=root
+    command: mysqld --sql_mode=""
     healthcheck:
         test: "mysql --host=easyminer-mysql --user=root --password=root  --execute='show databases' "
         interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+version: "2.1"
+services:
+  easyminer-mysql:
+    container_name: easyminer-mysql
+    image: mariadb:10
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    healthcheck:
+        test: "mysql --host=easyminer-mysql --user=root --password=root  --execute='show databases' "
+        interval: 15s
+        retries: 5
+  
+  easyminer-frontend:
+    container_name: easyminer-frontend
+    image: kizi/easyminer-frontend:v2.4
+    ports:
+      - "8894:80"
+    healthcheck:
+      test: "curl -f http://easyminer-frontend/easyminercenter"
+      interval: 30s
+      retries: 5  
+    depends_on:
+      easyminer-mysql:
+        condition: service_healthy 
+      easyminer-scorer:
+        condition: service_healthy     
+  
+  easyminer-backend:
+    container_name: easyminer-backend
+    image: kizi/easyminer-backend:v2.4
+    ports:
+      - "8891:8891"
+      - "8892:8892"
+      - "8893:8893"
+    environment:
+      - EM_USER_ENDPOINT=http://easyminer-frontend/easyminercenter
+    healthcheck:
+      test: "curl -f http://localhost:8891/easyminer-data/index.html && curl -f http://localhost:8892/easyminer-preprocessing/index.html && curl -f http://localhost:8893/easyminer-miner/index.html"
+      interval: 30s
+      retries: 5  
+    depends_on:
+      easyminer-frontend:
+        condition: service_healthy 
+
+  easyminer-scorer:
+    container_name: easyminer-scorer
+    image: kizi/easyminer-scorer:v2.4
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: "curl -f http://localhost:8080/swagger-ui.html"
+      interval: 30s
+      retries: 5
+
+  easyminer:
+    image: busybox:1
+    command: /bin/true
+    depends_on:
+      easyminer-frontend:
+        condition: service_healthy 
+      easyminer-backend:
+        condition: service_healthy 
+      easyminer-scorer:
+        condition: service_healthy 
+      easyminer-mysql:  
+        condition: service_healthy      


### PR DESCRIPTION
Proposing using Docker-compose instead of docker run command sequence for installation. Current installation commands does not guarantee container initialization in right order. This causes errors that are hard to diagnose.
Docker-compose solves this issues, due to using container dependency and service health checks. Also Docker compose is current standard for services that needs more than one container.